### PR TITLE
Fix requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.11
 pillow>=3.4
 plac>=0.9.6
-python-lmdb=0.92
-tqdm=4.19.4
+lmdb>=0.92
+tqdm>=4.19.4
 torch>=0.2.0


### PR DESCRIPTION
When installing the `requirements.txt` file with `pip`, it fails.
The python requirements contains `=` instead of `==` or `>=`. Additionally, `lmdb` is the correct database package and not `python-lmdb` from the package manager.

Anyways, thanks a lot for providing the implementation! :+1: 